### PR TITLE
feat(influx publisher): allow drivers to define measurement names

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   action-controller:
     git: https://github.com/spider-gazelle/action-controller.git
-    version: 4.5.1
+    version: 4.7.0
 
   active-model:
     git: https://github.com/spider-gazelle/active-model.git
@@ -70,7 +70,7 @@ shards:
 
   neuroplastic:
     git: https://github.com/spider-gazelle/neuroplastic.git
-    version: 1.8.0
+    version: 1.10.0
 
   openssl_ext:
     git: https://github.com/spider-gazelle/openssl_ext.git
@@ -82,7 +82,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 5.14.1
+    version: 5.15.2
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git
@@ -102,7 +102,7 @@ shards:
 
   rethinkdb:
     git: https://github.com/place-labs/crystal-rethinkdb.git
-    version: 0.3.1+git.commit.af92ace5eb60e861a41b93456ac5d73b80feb7bb
+    version: 0.3.1+git.commit.07ce7c694a367efe3af9f8cb5670bc4bff5b6df0
 
   rethinkdb-orm:
     git: https://github.com/spider-gazelle/rethinkdb-orm.git

--- a/spec/publishing/influx_publisher_spec.cr
+++ b/spec/publishing/influx_publisher_spec.cr
@@ -44,6 +44,7 @@ module PlaceOS::Source
           "pos_level"    => "nek",
           "pos_area"     => "2042",
           "pos_system"   => "cs-9445",
+          "pos_module"   => "M'Odule",
           "pos_index"    => "1",
         })
 
@@ -90,6 +91,7 @@ module PlaceOS::Source
           "pos_level"    => "nek",
           "pos_area"     => "2042",
           "pos_system"   => "cs-9445",
+          "pos_module"   => "M'Odule",
           "pos_index"    => "1",
         })
 
@@ -172,6 +174,7 @@ module PlaceOS::Source
           "pos_level"    => "nek",
           "pos_area"     => "2042",
           "pos_system"   => "cs-9445",
+          "pos_module"   => "M'Odule",
           "pos_index"    => "1",
           "pos_uniq"     => "0",
           "s2_cell_id"   => "12345",
@@ -212,6 +215,7 @@ module PlaceOS::Source
           "pos_level"    => "nek",
           "pos_area"     => "2042",
           "pos_system"   => "cs-9445",
+          "pos_module"   => "M'Odule",
           "pos_index"    => "1",
           "pos_uniq"     => "1",
         })

--- a/spec/publishing/publish_metadata_spec.cr
+++ b/spec/publishing/publish_metadata_spec.cr
@@ -37,7 +37,7 @@ module PlaceOS::Source
       mock = MockModel.new(id: "hello", some_data: "edkh")
       router.publish_metadata(zone, mock)
 
-      Fiber.yield
+      sleep 0.1
 
       router.@publisher_managers.first.messages.should be_empty
     end
@@ -52,7 +52,7 @@ module PlaceOS::Source
       router = Dummy.new
       router.publish_metadata(zone, mock)
 
-      Fiber.yield
+      sleep 0.1
 
       message = router.@publisher_managers.first.messages.first?
       message.should_not be_nil

--- a/src/source/publishing/influx_publisher.cr
+++ b/src/source/publishing/influx_publisher.cr
@@ -81,8 +81,8 @@ module PlaceOS::Source
         obj["pos_#{key}"] = data.zone_mapping[key]? || "_"
       end
       tags["pos_system"] = data.control_system_id
+      tags["pos_module"] = data.module_name
       tags["pos_index"] = data.index.to_i64.to_s
-      tags["mod_name"] = data.module_name
 
       fields = ::Flux::Point::FieldSet.new
 

--- a/src/source/publishing/influx_publisher.cr
+++ b/src/source/publishing/influx_publisher.cr
@@ -154,7 +154,6 @@ module PlaceOS::Source
 
       ts_map = raw.ts_map || {} of String => String
       points = Array(Flux::Point).new(initial_capacity: raw.value.size)
-
       default_measurement = raw.measurement
 
       raw.value.each_with_index do |val, index|
@@ -163,42 +162,46 @@ module PlaceOS::Source
         next if compacted.empty?
         measurement = default_measurement || data.module_name
 
-        # Add the fields
-        local_fields = fields.dup
-        compacted.each do |sub_key, value|
-          sub_key = (ts_map[sub_key]? || sub_key).gsub(/\W/, '_')
-          if sub_key == "measurement" && value.is_a?(String)
-            measurement = value
-          else
-            local_fields[sub_key] = value
-          end
-        end
-
         # Must include a `pos_uniq` tag for seperating points
         # as per: https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/duplicate-points/#add-an-arbitrary-tag
         local_tags = tags.dup
         local_tags["pos_uniq"] = index.to_s
 
-        # convert fields to tags as required
-        if ts_tag_keys = raw.ts_tag_keys
-          ts_tag_keys.each do |field|
-            field_value = local_fields.delete field
-            # might be `false`
-            if !field_value.nil?
-              local_tags[field] = field_value.to_s
-            end
-          end
-        end
-
-        points << Flux::Point.new!(
-          measurement: measurement,
-          timestamp: timestamp,
-          tags: local_tags,
-          pos_driver: data.driver_id,
-        ).tap &.fields.merge!(local_fields)
+        points << build_custom_point(measurement, data, fields, local_tags, compacted, timestamp, ts_map, raw.ts_tag_keys)
       end
 
       points
+    end
+
+    protected def self.build_custom_point(measurement, data, fields, local_tags, compacted, timestamp, ts_map, ts_tag_keys)
+      # Add the fields
+      local_fields = fields.dup
+      compacted.each do |sub_key, value|
+        sub_key = (ts_map[sub_key]? || sub_key).gsub(/\W/, '_')
+        if sub_key == "measurement" && value.is_a?(String)
+          measurement = value
+        else
+          local_fields[sub_key] = value
+        end
+      end
+
+      # convert fields to tags as required
+      if ts_tag_keys
+        ts_tag_keys.each do |field|
+          field_value = local_fields.delete field
+          # might be `false`
+          if !field_value.nil?
+            local_tags[field] = field_value.to_s
+          end
+        end
+      end
+
+      Flux::Point.new!(
+        measurement: measurement,
+        timestamp: timestamp,
+        tags: local_tags,
+        pos_driver: data.driver_id,
+      ).tap &.fields.merge!(local_fields)
     end
 
     protected def self.hmac_sha256(data : String)


### PR DESCRIPTION
this mostly effects the more complex measurements being taken so a single driver like AreaManagement can output wireless, desk and space measurements - making it easier to query the data.